### PR TITLE
Code blocks not being rendered (missing paragraph)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,7 @@ serializer)
 to be serialized as the "geometry". For example:
 
 .. code-block:: python
+
     from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
     class LocationSerializer(GeoFeatureModelSerializer):
@@ -175,6 +176,7 @@ automatically put outside the "properties" object (before "type") unless
 **``id_field``** is set to False:
 
 .. code-block:: python
+
     from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
     class LocationSerializer(GeoFeatureModelSerializer):
@@ -189,6 +191,7 @@ You could also set the **``id_field``** to some other unique field in
 your model, like **"slug"**:
 
 .. code-block:: python
+
     from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
     class LocationSerializer(GeoFeatureModelSerializer):


### PR DESCRIPTION
Just adding a line after the ' .. code-block:: python' as they weren't being rendered on the main github page.
