### PR TITLE
Implement release workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,12 @@
+name: Compliance
+
+on: [pull_request]
+
+jobs:
+ Changelog:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: actions/checkout@v1
+   - name: Check that CHANGELOG is touched
+     run: |
+       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.rst

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: PyPi Release
+
+on: [release]
+
+jobs:
+  PyPi release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade pip setuptools wheel twine
+    - uses: actions/setup-node@v1
+    - name: Install Node dependencies
+      run: npm install --only=dev
+    - name: Minify JavaScript files
+      run: npm run-script minify
+    - name: Build dist packages
+      run: python setup.py sdist bdist_wheel
+    - name: Upload packages
+      run: python -m twine upload dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+Version master [unreleased]
+-------------------
+
+- `#202 <https://github.com/djangonauts/django-rest-framework-gis/pull/202>`_:
+  update DRF to 3.10
+
+- `#192 <https://github.com/djangonauts/django-rest-framework-gis/pull/192>`_:
+  fix Docker build
+
+- `#200 <https://github.com/djangonauts/django-rest-framework-gis/pull/200>`_:
+  Add Django 3.0 and Python 3.8 support
+
+- `#195 <https://github.com/djangonauts/django-rest-framework-gis/pull/195>`_:
+  Update the way that ``to_representation`` removes already processed
+
+- `#197 <https://github.com/djangonauts/django-rest-framework-gis/pull/197>`_:
+  Removed six dependency
+
+- `#199 <https://github.com/djangonauts/django-rest-framework-gis/pull/199>`_:
+  Drop Django 2.0 support
+
+- `#190 <https://github.com/djangonauts/django-rest-framework-gis/pull/190>`_:
+  Added django 2.2 on test matrix
+
+- Drop Python 3.4 support
+
 Version 0.14.0 [2018-12-02]
 ---------------------------
 


### PR DESCRIPTION
This will enable automatic releases for each GitHub release that is created and will allow all djangonauts to relesae.

It will require every contributor to write a release note.

The person that releases should update to the correct version number and date.

After this is merged someone needs to set two secrets to the GitHub repo (in the settings):
- [ ] `TWINE_USERNAME`
- [ ] `TWINE_PASSWORD`
