### PR TITLE
Improve README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,10 @@ In contrast, the ``GeoModelSerializer`` will output:
         }
     }
 
-**Note:** The DRF model serializer will also give the same output as above, provided
-that you are using ``ver>=0.9.3``, and you have included ``rest_framework_gis`` in
-``settings.INSTALLED_APPS``.
+**Note:** For ``ver>=0.9.3``: The DRF model serializer will give the same output as above, if;
+
+-  ``rest_framework_gis`` is set in ``settings.INSTALLED_APPS`` or
+-  the field in the serializer is set explicitly as ``GeometryField``.
 
 GeoFeatureModelSerializer
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Relating to: https://github.com/openwisp/django-rest-framework-gis/issues/207
Improves description for using GeoJSON serializer without setting ``rest_framework_gis`` in ``settings.py``