### PR TITLE
[ci] Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - sudo apt-get update -q
   - sudo apt-get install binutils libproj-dev gdal-bin -y
 install:
-  - pip install coverage tox
+  - pip install tox
   - pip install docutils pygments  # for setup.py check -r -s
 
 before_script:
@@ -40,8 +40,5 @@ before_script:
   - psql -U postgres -d django_restframework_gis -c "CREATE EXTENSION postgis;"
 
 script:
-  - coverage run --source=rest_framework_gis $(command -v tox)
+  - tox -e travis
   - python setup.py check -r -s
-
-after_success:
-  coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 psycopg2
-coverage==3.7.1  # rq.filter: >=3,<4
 coveralls
 django-filter>=2.0
 contexttimer

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,16 @@ envlist =
 
 [testenv]
 usedevelop = true
+passenv = TRAVIS TRAVIS_*
 setenv =
     DJANGO_SETTINGS_MODULE=settings
     ; Hack: use an environment var to specify the test runner (to avoid using
     ; "nopytest" as a factor).
-    DRFG_TEST_RUNNER=python ./tests/manage.py test
-    pytest: DRFG_TEST_RUNNER=pytest
+    DRFG_TEST_RUNNER=./tests/manage.py test
+    pytest: DRFG_TEST_RUNNER=-m pytest
 commands =
-    {env:DRFG_TEST_RUNNER} {posargs:tests/django_restframework_gis_tests}
+    coverage run --source=rest_framework_gis {env:DRFG_TEST_RUNNER} {posargs:tests/django_restframework_gis_tests}
+    travis: - coveralls
 
 deps =
     django111: Django~=1.11


### PR DESCRIPTION
According to [the official docs](https://github.com/coveralls-clients/coveralls-python/blob/master/docs/usage/tox.rst), coveralls and coverage should have been run in tox, so coverage can collect the test data. Also remove coverage dependency because coveralls already has a dependency on coverage. Minor fix to tox.ini included so coverage can run properly.
I add `travis` as env to prevent coveralls run on local tox test, and add `-` in before `coveralls` call to ignore the exit code because build is considered success even though coveralls failed (in respect to other repos that calls `coveralls` in `after_success`)