### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -562,8 +562,8 @@ class TestRestFrameworkGis(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         location_reloaded = Location.objects.get(pk=location.id)
-        self.assertEquals(location_reloaded.name, 'geojson successful patch test')
-        self.assertEquals(
+        self.assertEqual(location_reloaded.name, 'geojson successful patch test')
+        self.assertEqual(
             location_reloaded.geometry, Point(10.1, 10.1, srid=location.geometry.srid)
         )
 
@@ -578,8 +578,8 @@ class TestRestFrameworkGis(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         location_reloaded = Location.objects.get(pk=location.id)
-        self.assertEquals(location_reloaded.name, 'geojson successful patch test')
-        self.assertEquals(
+        self.assertEqual(location_reloaded.name, 'geojson successful patch test')
+        self.assertEqual(
             location_reloaded.geometry, Point(135.0, 45.0, srid=location.geometry.srid)
         )
 


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268