### PR TITLE
Replace ugettext_lazy usages with gettext_lazy

### DIFF
--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import Field, SerializerMethodField
 
 __all__ = ['GeometryField', 'GeometrySerializerMethodField']


### PR DESCRIPTION
`ugettext_lazy` has been deprecated since 3.0, and django 4.0 removed it thus making this library unusable with django 4.0.

This change should not break anything as from my understanding, ugettext was there for Python 2 compatibility.