### PR TITLE
[feat] Bounding Box support for Point, Line, Polygon, ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Provides a ``GeometryField``, which is a subclass of Django Rest Framework
 geometry fields, providing custom ``to_native`` and ``from_native``
 methods for GeoJSON input/output.
 
-This field takes two optional arguments:
+This field takes three optional arguments:
 
 ``precision``: Passes coordinates through Python's builtin ``round()`` function (`docs
 <https://docs.python.org/3/library/functions.html#round>`_), rounding values to
@@ -92,7 +92,9 @@ polygon geometries. This is particularly useful when used with the ``precision``
 argument, as the likelihood of duplicate coordinates increase as precision of
 coordinates are reduced.
 
-**Note:** While both above arguments are designed to reduce the
+``auto_bbox``: If True, the GeoJSON object will include a `bounding box <https://datatracker.ietf.org/doc/html/rfc7946#section-5>`_, which is the smallest possible rectangle enclosing the geometry.
+
+**Note:** While ``precision`` and ``remove_duplicates`` are designed to reduce the
 byte size of the API response, they will also increase the processing time
 required to render the response. This will likely be negligible for small GeoJSON
 responses but may become an issue for large responses.

--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -17,8 +17,14 @@ class GeometryField(Field):
 
     type_name = 'GeometryField'
 
-    def __init__(self, precision=None, remove_duplicates=False, **kwargs):
+    def __init__(
+        self, precision=None, remove_duplicates=False, auto_bbox=False, **kwargs
+    ):
+        """
+        :param auto_bbox: Whether the GeoJSON object should include a bounding box
+        """
         self.precision = precision
+        self.auto_bbox = auto_bbox
         self.remove_dupes = remove_duplicates
         super().__init__(**kwargs)
         self.style.setdefault('base_template', 'textarea.html')
@@ -45,6 +51,9 @@ class GeometryField(Field):
                 geometry['coordinates'] = self._rm_redundant_points(
                     geometry['coordinates'], geometry['type']
                 )
+
+        if self.auto_bbox:
+            geojson["bbox"] = value.extent
         return geojson
 
     def to_internal_value(self, value):

--- a/tests/django_restframework_gis_tests/test_fields.py
+++ b/tests/django_restframework_gis_tests/test_fields.py
@@ -586,3 +586,95 @@ class TestRmRedundant(BaseTestCase):
                 }
             },
         )
+
+
+class TestBoundingBox(BaseTestCase):
+    def test_boundingbox_Point(self):
+        model = self.get_instance(Point)
+        Serializer = self.create_serializer(auto_bbox=True)
+        data = Serializer(model).data
+        self.assertEqual(
+            self.normalize(data),
+            {
+                'geometry': {
+                    "type": "Point",
+                    "bbox": [-105.0162, 39.5742, -105.0162, 39.5742],
+                    "coordinates": [-105.0162, 39.5742],
+                }
+            },
+        )
+
+    def test_boundingbox_MultiPoint(self):
+        model = self.get_instance(MultiPoint)
+        Serializer = self.create_serializer(auto_bbox=True)
+        data = Serializer(model).data
+        self.assertEqual(
+            self.normalize(data),
+            {
+                "geometry": {
+                    "type": "MultiPoint",
+                    "bbox": [-105.0162, 35.049, -80.6665, 39.5742],
+                    "coordinates": [
+                        [-105.0162, 39.5742],
+                        [-80.6665, 35.0539],
+                        [-80.6665, 35.0539],
+                        [-80.672, 35.049],
+                    ],
+                }
+            },
+        )
+
+    def test_boundingbox_LineString(self):
+        model = self.get_instance(LineString)
+        Serializer = self.create_serializer(auto_bbox=True)
+        data = Serializer(model).data
+        self.assertEqual(
+            self.normalize(data),
+            {
+                "geometry": {
+                    "type": "LineString",
+                    "bbox": [-101.7443, 38.8739, -97.6354, 39.33],
+                    "coordinates": [
+                        [-101.7443, 39.3215],
+                        [-101.4021, 39.3300],
+                        [-101.4038, 39.3300],
+                        [-101.4038, 39.3300],
+                        [-97.6354, 38.8739],
+                    ],
+                }
+            },
+        )
+
+    def test_boundingbox_Polygon(self):
+        model = self.get_instance(Polygon)
+        Serializer = self.create_serializer(auto_bbox=True)
+        data = Serializer(model).data
+        self.assertEqual(
+            self.normalize(data),
+            {
+                "geometry": {
+                    "type": "Polygon",
+                    "bbox": [-84.3228, 34.985, -82.5677, 36.0335],
+                    "coordinates": [
+                        [
+                            [-84.3228, 34.9895],
+                            [-82.6062, 36.0335],
+                            [-82.6062, 35.9913],
+                            [-82.6062, 35.9791],
+                            [-82.5787, 35.9613],
+                            [-82.5787, 35.9613],  # Dupe
+                            [-82.5677, 35.9513],
+                            [-84.2211, 34.9850],
+                            [-84.3228, 34.9895],
+                        ],
+                        [
+                            [-75.6903, 35.7420],
+                            [-75.5914, 35.7420],
+                            [-75.5914, 35.7420],  # Dupe
+                            [-75.7067, 35.7420],
+                            [-75.6903, 35.7420],
+                        ],
+                    ],
+                }
+            },
+        )


### PR DESCRIPTION
The [GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946#section-5) allows GeoJSON objects of all types (Feature, Point, Polygon, ...) to contain a bounding box.

https://github.com/openwisp/django-rest-framework-gis/pull/57 already added support for bounding boxes for Features.

This patch adds bounding box support for all remaining types and introduces a new argument `auto_bbox` on the `GeometryField`. 

## Example
Model:
```
class Location(models.Model):
    name = models.CharField(...)
    geometry = geomodels.PolygonField()
```

Serializer:
```
class LocationSerializer(serializers.ModelSerializer):
    geometry = GeometryField(auto_bbox=True)

    class Meta:
        model = Location
        fields = ["name", "geometry"]
```

Serialization:
```
{
   "name": "lorem ipsum",
   "geometry": {
            "type": "Polygon",
            "bbox": [8.0, 39.0, 8.02, 39.02]
            "coordinates": [[[8.0, 39.0], [8.02, 39.01], [8.01, 39.02], [8.0, 39.0]]],
        }
}
```






