### PR TITLE
Fix : django-filter looks for 'filterset_class' attribute now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
 
       - name: QA checks
         run: |
+          pip install "importlib-metadata<5.0"  # remove when flake8 is upgraded
           ./run-qa-checks
 
   coveralls:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,6 @@ jobs:
           pip install -U -r requirements-test.txt
           pip install tox docutils pygments twine
 
-      - name: QA checks
-        run: |
-          ./run-qa-checks
-
       - name: Tests
         run: |
           tox -e ${{ matrix.env.TOXENV }}
@@ -109,6 +105,10 @@ jobs:
           COVERALLS_FLAG_NAME: |
            python-${{ matrix.env.env }}
           COVERALLS_PARALLEL: true
+
+      - name: QA checks
+        run: |
+          ./run-qa-checks
 
   coveralls:
     name: Finish Coveralls

--- a/rest_framework_gis/filters.py
+++ b/rest_framework_gis/filters.py
@@ -116,7 +116,7 @@ class GeometryFilter(django_filters.Filter):
 
 class GeoFilterSet(django_filters.FilterSet):
     GEOFILTER_FOR_DBFIELD_DEFAULTS = {
-        models.GeometryField: {'filter_class': GeometryFilter},
+        models.GeometryField: {'filterset_class': GeometryFilter},
     }
 
     def __new__(cls, *args, **kwargs):

--- a/tests/django_restframework_gis_tests/views.py
+++ b/tests/django_restframework_gis_tests/views.py
@@ -208,7 +208,7 @@ class LocationFilter(GeoFilterSet):
 class GeojsonLocationContainedInGeometry(generics.ListAPIView):
     queryset = Location.objects.all()
     serializer_class = LocationGeoSerializer
-    filter_class = LocationFilter
+    filterset_class = LocationFilter
 
     filter_backends = (DjangoFilterBackend,)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -81,6 +81,6 @@ REST_FRAMEWORK = {
 
 # local settings must be imported before test runner otherwise they'll be ignored
 try:
-    from local_settings import *
+    from local_settings import *  # noqa
 except ImportError:
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
 
 [testenv]
 usedevelop = true
-passenv = TRAVIS TRAVIS_*
 setenv =
     DJANGO_SETTINGS_MODULE=settings
     ; Hack: use an environment var to specify the test runner (to avoid using
@@ -29,3 +28,6 @@ deps =
     -rrequirements-test.txt
     pytest: pytest
     pytest: pytest-django
+
+[flake8]
+exclude = .tox


### PR DESCRIPTION
The test `tests.django_restframework_gis_tests.test_filters.TestRestFrameworkGisFilters.test_GeometryField_filtering` was failing. After checking my database logs, it seemed that postgres was not receiving the right query, as the where clause was missing.

I looked a bit into the django-filter setup and it needed an update.  

The fix was to rename the attribute `filter_class` to `filterset_class`, as per [the doc](https://django-filter.readthedocs.io/en/stable/guide/rest_framework.html#adding-a-filterset-with-filterset-class).