### PR TITLE
Remove Django 3.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,27 +30,9 @@ jobs:
       matrix:
         env:
           - python: '3.8'
-            TOXENV: py38-django32-djangorestframework312
-          - python: '3.8'
-            TOXENV: py38-django32-djangorestframework313
-          - python: '3.8'
-            TOXENV: py38-django32-djangorestframework314
-          - python: '3.8'
             TOXENV: py38-django42-djangorestframework314
           - python: '3.9'
-            TOXENV: py39-django32-djangorestframework312
-          - python: '3.9'
-            TOXENV: py39-django32-djangorestframework313
-          - python: '3.9'
-            TOXENV: py39-django32-djangorestframework314
-          - python: '3.9'
             TOXENV: py39-django42-djangorestframework314
-          - python: '3.10'
-            TOXENV: py310-django32-djangorestframework312
-          - python: '3.10'
-            TOXENV: py310-django32-djangorestframework313
-          - python: '3.10'
-            TOXENV: py310-django32-djangorestframework314
           - python: '3.10'
             TOXENV: py310-django42-djangorestframework314
           - python: '3.11'

--- a/README.rst
+++ b/README.rst
@@ -692,11 +692,11 @@ The recommended way to run the tests is by using
 `pip install tox`.
 
 You can use ``tox -l`` to list the available environments, and then e.g. use
-the following to run all tests with Python 3.6 and Django 1.11:
+the following to run all tests with Python 3.8 and Django 4.2:
 
 .. code-block:: bash
 
-    tox -e py36-django111
+    tox -e py38-django42
 
 By default Django's test runner is used, but there is a variation of tox's
 envlist to use pytest (using the ``-pytest`` suffix).
@@ -705,7 +705,7 @@ You can pass optional arguments to the test runner like this:
 
 .. code-block:: bash
 
-    tox -e py36-django111-pytest -- -k test_foo
+    tox -e py38-django42-pytest -- -k test_foo
 
 Running tests manually
 ======================

--- a/README.rst
+++ b/README.rst
@@ -602,7 +602,7 @@ at latitudes > 60 degrees are > 25%.
 DistanceToPointOrderingFilter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Provides a ``DistanceToPointOrderingFilter``, **available on Django >= 3.0**, which is a subclass of ``DistanceToPointFilter``.
+Provides a ``DistanceToPointOrderingFilter``, which is a subclass of ``DistanceToPointFilter``.
 Orders a queryset by distance to a given point, from the nearest to the most distant point.
 
 ``views.py:``

--- a/rest_framework_gis/__init__.py
+++ b/rest_framework_gis/__init__.py
@@ -12,12 +12,3 @@ def get_version():
         if VERSION[3] != 'final':
             version = '%s %s' % (version, VERSION[3])
     return version
-
-
-try:
-    import django
-
-    if django.VERSION < (3, 2):
-        default_app_config = 'rest_framework_gis.apps.AppConfig'
-except ImportError:
-    pass

--- a/rest_framework_gis/filters.py
+++ b/rest_framework_gis/filters.py
@@ -2,6 +2,8 @@ from math import cos, pi
 
 from django.contrib.gis import forms
 from django.contrib.gis.db import models
+from django.contrib.gis.db.models.fields import BaseSpatialField
+from django.contrib.gis.db.models.functions import GeometryDistance
 from django.contrib.gis.geos import Point, Polygon
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
@@ -17,24 +19,8 @@ except ImportError:  # pragma: no cover
         'restframework-gis filters depend on package "django-filter" '
         'which is missing. Install with "pip install django-filter".'
     )
-try:
-    # Django >= 2.0
-    from django.contrib.gis.db.models.fields import BaseSpatialField
-except ImportError:
-    try:  # pragma: no cover
-        # django >= 1.8,<2.0
-        from django.contrib.gis.db.models.lookups import gis_lookups
-    except ImportError:  # pragma: no cover
-        # django <= 1.7
-        gis_lookups = models.sql.query.ALL_TERMS
-else:
-    gis_lookups = BaseSpatialField.get_lookups()
 
-try:
-    # Django >= 3.0
-    from django.contrib.gis.db.models.functions import GeometryDistance
-except ImportError:
-    GeometryDistance = None
+gis_lookups = BaseSpatialField.get_lookups()
 
 
 __all__ = [
@@ -273,9 +259,6 @@ class DistanceToPointOrderingFilter(DistanceToPointFilter):
     order_param = 'order'
 
     def filter_queryset(self, request, queryset, view):
-        if not GeometryDistance:
-            raise ValueError('GeometryDistance not available on this version of django')
-
         filter_field = getattr(view, 'distance_ordering_filter_field', None)
 
         if not filter_field:

--- a/tests/django_restframework_gis_tests/admin.py
+++ b/tests/django_restframework_gis_tests/admin.py
@@ -4,8 +4,6 @@ from django.contrib.gis.admin import ModelAdmin as GeoModelAdmin
 from .models import Location
 
 
+@admin.register(Location)
 class LocationAdmin(GeoModelAdmin):
     list_display = ('name', 'geometry')
-
-
-admin.site.register(Location, LocationAdmin)

--- a/tests/django_restframework_gis_tests/test_bbox.py
+++ b/tests/django_restframework_gis_tests/test_bbox.py
@@ -1,13 +1,8 @@
 import json
 
-from django.test import TestCase
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
-
 from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from django.urls import reverse
 
 from rest_framework_gis import serializers as gis_serializers
 

--- a/tests/django_restframework_gis_tests/test_filters.py
+++ b/tests/django_restframework_gis_tests/test_filters.py
@@ -3,13 +3,10 @@ import urllib
 from unittest import skipIf
 
 from django.conf import settings
+from django.contrib.gis.db.models.functions import GeometryDistance
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .models import Location
 from .views import (
@@ -22,13 +19,6 @@ has_spatialite = (
     settings.DATABASES['default']['ENGINE']
     == 'django.contrib.gis.db.backends.spatialite'
 )
-
-try:
-    from django.contrib.gis.db.models.functions import GeometryDistance
-
-    has_geometry_distance = GeometryDistance and True
-except ImportError:
-    has_geometry_distance = False
 
 
 class TestRestFrameworkGisFilters(TestCase):
@@ -349,10 +339,6 @@ class TestRestFrameworkGisFilters(TestCase):
         has_spatialite,
         'Skipped test for spatialite backend: missing feature "GeometryDistance"',
     )
-    @skipIf(
-        not has_geometry_distance,
-        'Skipped test for Django < 3.0: missing feature "GeometryDistance"',
-    )
     def test_DistanceToPointOrderingFilter_filtering(self):
         """
         Checks that the DistanceOrderingFilter returns the objects in the correct order
@@ -563,10 +549,6 @@ class TestRestFrameworkGisFilters(TestCase):
             'Invalid distance string supplied for parameter dist',
         )
 
-    @skipIf(
-        not has_geometry_distance,
-        'Skipped test for Django < 3.0: missing feature "GeometryDistance"',
-    )
     def test_DistanceToPointOrderingFilter_filtering_none(self):
         url_params = '?point=&format=json'
         response = self.client.get(
@@ -576,10 +558,6 @@ class TestRestFrameworkGisFilters(TestCase):
             response.data, {'type': 'FeatureCollection', 'features': []}
         )
 
-    @skipIf(
-        not has_geometry_distance,
-        'Skipped test for Django < 3.0: missing feature "GeometryDistance"',
-    )
     def test_DistanceToPointOrderingFilter_ordering_filter_field_none(self):
         original_value = (
             GeojsonLocationOrderDistanceToPointList.distance_ordering_filter_field
@@ -595,11 +573,3 @@ class TestRestFrameworkGisFilters(TestCase):
         GeojsonLocationOrderDistanceToPointList.distance_ordering_filter_field = (
             original_value
         )
-
-    @skipIf(has_geometry_distance, 'Skipped test for Django >= 3.0')
-    def test_DistanceToPointOrderingFilter_not_available(self):
-        url_params = '?point=12,42&format=json'
-        with self.assertRaises(ValueError):
-            self.client.get(
-                '%s%s' % (self.location_order_distance_to_point, url_params)
-            )

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -8,16 +8,11 @@ import sys
 from unittest import skipIf
 
 import django
-from django.contrib.gis.geos import GEOSGeometry, Point
-from django.test import TestCase
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
-
 import rest_framework
+from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from django.urls import reverse
 
 from rest_framework_gis import serializers as gis_serializers
 from rest_framework_gis.fields import GeoJsonDict
@@ -40,16 +35,10 @@ class TestRestFrameworkGis(TestCase):
             'Unable to convert to python object:'
             ' Invalid geometry pointer returned from "OGR_G_CreateGeometryFromJson".'
         )
-        if django.VERSION >= (2, 0, 0):
-            self.value_error_message = (
-                "Unable to convert to python object:"
-                " String input unrecognized as WKT EWKT, and HEXEWKB."
-            )
-        else:
-            self.value_error_message = (
-                "Unable to convert to python object:"
-                " String or unicode input unrecognized as WKT EWKT, and HEXEWKB."
-            )
+        self.value_error_message = (
+            "Unable to convert to python object:"
+            " String input unrecognized as WKT EWKT, and HEXEWKB."
+        )
         self.type_error_message = (
             "Unable to convert to python object: Improper geometry input type:"
         )

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -133,7 +133,7 @@ class TestRestFrameworkGis(TestCase):
             ),
         }
         response = self.client.post(
-            self.location_list_url, data, HTTP_ACCEPT='text/html'
+            self.location_list_url, data, headers={"accept": 'text/html'}
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -289,7 +289,7 @@ class TestRestFrameworkGis(TestCase):
             self.assertCountEqual(json.dumps(response.data), json.dumps(expected))
         else:
             self.assertItemsEqual(json.dumps(response.data), json.dumps(expected))
-        response = self.client.get(url, HTTP_ACCEPT='text/html')
+        response = self.client.get(url, headers={"accept": 'text/html'})
         self.assertContains(response, "Kool geojson test")
 
     def test_geojson_id_attribute(self):
@@ -391,7 +391,7 @@ class TestRestFrameworkGis(TestCase):
             self.geojson_location_list_url,
             data=json.dumps(data),
             content_type='application/json',
-            HTTP_ACCEPT='text/html',
+            headers={"accept": 'text/html'},
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -495,12 +495,12 @@ class TestRestFrameworkGis(TestCase):
 
     def test_HTML_browsable_geojson_location_list(self):
         response = self.client.get(
-            self.geojson_location_list_url, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, headers={"accept": 'text/html'}
         )
         self.assertEqual(response.status_code, 200)
         self._create_locations()
         response = self.client.get(
-            self.geojson_location_list_url, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, headers={"accept": 'text/html'}
         )
         self.assertContains(response, 'l1')
         self.assertContains(response, 'l2')
@@ -512,7 +512,7 @@ class TestRestFrameworkGis(TestCase):
             "geometry": json.dumps({"type": "Point", "coordinates": [10.1, 10.1]}),
         }
         response = self.client.post(
-            self.geojson_location_list_url, data, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, data, headers={"accept": 'text/html'}
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -524,7 +524,7 @@ class TestRestFrameworkGis(TestCase):
         self.assertEqual(Location.objects.count(), 0)
         data = {"name": "HTML test WKT", "geometry": "POINT (10.1 10.1)"}
         response = self.client.post(
-            self.geojson_location_list_url, data, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, data, headers={"accept": 'text/html'}
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -535,7 +535,7 @@ class TestRestFrameworkGis(TestCase):
     def test_geojson_HTML_widget_value(self):
         self._create_locations()
         response = self.client.get(
-            self.geojson_location_list_url, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, headers={"accept": 'text/html'}
         )
         self.assertContains(response, '<textarea name="geometry"')
         self.assertContains(response, '"type": "Point"')
@@ -545,7 +545,7 @@ class TestRestFrameworkGis(TestCase):
     def test_geojson_HTML_widget_value_pre_drf_39(self):
         self._create_locations()
         response = self.client.get(
-            self.geojson_location_list_url, HTTP_ACCEPT='text/html'
+            self.geojson_location_list_url, headers={"accept": 'text/html'}
         )
         self.assertContains(response, '<textarea name="geometry"')
         self.assertContains(response, '&quot;type&quot;: &quot;Point&quot;')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{38,39,310}-django{32}-djangorestframework{312,313,314}{,-pytest}
     py{38,39,310}-django{42,50}-djangorestframework{314}{,-pytest}
     py{311}-django{42}-djangorestframework{314}{,-pytest}
     py{311,312}-django{50}-djangorestframework{315}{,-pytest}
@@ -18,7 +17,6 @@ commands =
     coverage run {env:DRFG_TEST_RUNNER} {posargs:tests/django_restframework_gis_tests} --parallel
 
 deps =
-    django32: Django~=3.2.0
     django42: Django~=4.2.0
     django50: Django~=5.0.0
     django51: Django~=5.1.0


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #312

## Description of Changes

* Removes any compatibility code or doc for <4.2 versions of Django
* Remove 3.2 from CI and docs
* Modernize the code for Django 4.2 with the help of django-upgrade

