### PR TITLE
[cleanup] Remove Python 3.8 env from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-django{42,50}-djangorestframework{314}{,-pytest}
+    py{39,310}-django{42,50}-djangorestframework{314}{,-pytest}
     py{311}-django{42}-djangorestframework{314}{,-pytest}
     py{311,312}-django{50}-djangorestframework{315}{,-pytest}
     py{311,312}-django{51}-djangorestframework{315}{,-pytest}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.

## Reference to Existing Issue

Refers to 
- https://github.com/openwisp/django-rest-framework-gis/issues/314
- https://github.com/openwisp/django-rest-framework-gis/pull/317

## Description of Changes

I missed the 3.8 related config in tox file in https://github.com/openwisp/django-rest-framework-gis/pull/317
