### PR TITLE
[cleanup] Drop support for untested DRF versions

### DIFF
--- a/rest_framework_gis/apps.py
+++ b/rest_framework_gis/apps.py
@@ -13,12 +13,7 @@ class AppConfig(BaseConfig):
 
         from .fields import GeometryField
 
-        try:
-            # drf 3.0
-            field_mapping = ModelSerializer._field_mapping.mapping
-        except AttributeError:
-            # drf 3.1
-            field_mapping = ModelSerializer.serializer_field_mapping
+        field_mapping = ModelSerializer.serializer_field_mapping
 
         # map GeoDjango fields to drf-gis GeometryField
         field_mapping.update(

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -4,9 +4,7 @@ unit tests for restframework_gis
 
 import json
 import pickle
-from unittest import skipIf
 
-import rest_framework
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
@@ -17,8 +15,6 @@ from rest_framework_gis.fields import GeoJsonDict
 
 from .models import LocatedFile, Location, Nullable
 from .serializers import LocationGeoSerializer
-
-is_pre_drf_39 = not rest_framework.VERSION.startswith('3.9')
 
 
 class TestRestFrameworkGis(TestCase):
@@ -526,7 +522,6 @@ class TestRestFrameworkGis(TestCase):
         location = Location.objects.all()[0]
         self.assertEqual(location.name, "HTML test WKT")
 
-    @skipIf(is_pre_drf_39, 'Skip this test if DRF < 3.9')
     def test_geojson_HTML_widget_value(self):
         self._create_locations()
         response = self.client.get(
@@ -535,16 +530,6 @@ class TestRestFrameworkGis(TestCase):
         self.assertContains(response, '<textarea name="geometry"')
         self.assertContains(response, '"type": "Point"')
         self.assertContains(response, '"coordinates": [')
-
-    @skipIf(not is_pre_drf_39, 'Skip this test if DRF >= 3.9')
-    def test_geojson_HTML_widget_value_pre_drf_39(self):
-        self._create_locations()
-        response = self.client.get(
-            self.geojson_location_list_url, headers={"accept": 'text/html'}
-        )
-        self.assertContains(response, '<textarea name="geometry"')
-        self.assertContains(response, '&quot;type&quot;: &quot;Point&quot;')
-        self.assertContains(response, '&quot;coordinates&quot;: [')
 
     def test_patch_geojson_location(self):
         location = Location.objects.create(

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -4,6 +4,7 @@ unit tests for restframework_gis
 
 import json
 import pickle
+from html import escape
 
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.exceptions import ImproperlyConfigured
@@ -528,8 +529,8 @@ class TestRestFrameworkGis(TestCase):
             self.geojson_location_list_url, headers={"accept": 'text/html'}
         )
         self.assertContains(response, '<textarea name="geometry"')
-        self.assertContains(response, '"type": "Point"')
-        self.assertContains(response, '"coordinates": [')
+        self.assertContains(response, escape('"type": "Point"'))
+        self.assertContains(response, escape('"coordinates": ['))
 
     def test_patch_geojson_location(self):
         location = Location.objects.create(

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ deps =
     django42: Django~=4.2.0
     django50: Django~=5.0.0
     django51: Django~=5.1.0
-    djangorestframework312: djangorestframework~=3.12.0
-    djangorestframework313: djangorestframework~=3.13.0
     djangorestframework314: djangorestframework~=3.14.0
     djangorestframework315: djangorestframework~=3.15.0
     -rrequirements-test.txt


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #320 .

## Description of Changes

* Remove unused DRF environments from tox config
* Remove compatibility code for unsupported DRF versions
